### PR TITLE
Move store init to config

### DIFF
--- a/src/Minion.Core/BatchEngine.cs
+++ b/src/Minion.Core/BatchEngine.cs
@@ -61,8 +61,6 @@ namespace Minion.Core
 
             _cts = new CancellationTokenSource();
 
-            Task.Run(() => _store.InitAsync(), _cts.Token).Wait();
-
             _heartBeatTask = HeartBeatAsync(_cts.Token);
             _engineTask = ExecuteAsync(_cts.Token);
         }

--- a/src/Minion.Core/MinionConfiguration.cs
+++ b/src/Minion.Core/MinionConfiguration.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Minion.Core.Interfaces;
 
 namespace Minion.Core
@@ -29,6 +31,9 @@ namespace Minion.Core
         public void UseBatchStore(IBatchStore store)
         {
             Store = store;
+            
+            var cts = new CancellationTokenSource();
+            Task.Run(() => Store.InitAsync(), cts.Token).Wait(cts.Token);
         }
 
         public void UseDependencyResolver(IDependencyResolver resolver)


### PR DESCRIPTION
Hi!

First of all, thanks for your work! But playing with the samples I noticed that I have some SQL related issue. I digged into the code a bit and found that I tried to queue a job, but the job table is not created yet. So, I thought since the code defines the usage of SQL as a store via configuration, maybe it would be a good idea to initialize it there.

If you think that this is not the issue (or this behaviour is intentional), please feel free to close/remove this PR and branch.