### PR TITLE
Fix/refactor job executor

### DIFF
--- a/src/Minion.Core/BatchEngine.cs
+++ b/src/Minion.Core/BatchEngine.cs
@@ -10,7 +10,7 @@ namespace Minion.Core
     public class BatchEngine : IDisposable
     {
         private readonly IBatchStore _store;
-        private readonly IJobExecutor _jobExecutor;
+        private readonly IJobExecutor _jobExecutor = new DependencyInjectionJobExecutor();
         private readonly ILogger _logger;
         private readonly BatchSettings _settings;
 
@@ -22,7 +22,6 @@ namespace Minion.Core
         public BatchEngine()
         {
             _store = MinionConfiguration.Configuration.Store;
-            _jobExecutor = new DependencyInjectionJobExecutor(MinionConfiguration.Configuration.DependencyResolver);
             _logger = MinionConfiguration.Configuration.Logger;
             _settings = new BatchSettings
             {
@@ -32,10 +31,9 @@ namespace Minion.Core
             };
         }
 
-        public BatchEngine(IBatchStore store, IDependencyResolver resolver, ILogger logger, BatchSettings batchSettings)
+        public BatchEngine(IBatchStore store, ILogger logger, BatchSettings batchSettings)
         {
             _store = store;
-            _jobExecutor = new DependencyInjectionJobExecutor(resolver);
             _logger = logger;
             _settings = batchSettings ?? new BatchSettings();
         }
@@ -155,7 +153,7 @@ namespace Minion.Core
 
             try
             {
-                result = await _jobExecutor.ExecuteAsync(job);
+                result = await _jobExecutor.ExecuteAsync(job, MinionConfiguration.Configuration.DependencyResolver);
             }
             catch (Exception e)
             {

--- a/src/Minion.Core/DependencyInjectionJobExecutor.cs
+++ b/src/Minion.Core/DependencyInjectionJobExecutor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -10,44 +9,35 @@ namespace Minion.Core
 {
 	internal class DependencyInjectionJobExecutor : IJobExecutor
 	{
-		private readonly IDependencyResolver _resolver;
-
-		public DependencyInjectionJobExecutor(IDependencyResolver resolver)
-		{
-			_resolver = resolver;
-		}
-
-		public Task<JobResult> ExecuteAsync(JobDescription jobDescription)
+		public Task<JobResult> ExecuteAsync(JobDescription jobDescription, IDependencyResolver resolver = null)
 		{
 			var type = Type.GetType(jobDescription.Type);
-
 			var typeInfo = type.GetTypeInfo();
+			ConstructorInfo ctor = typeInfo.GetConstructors().Single();
+			ParameterInfo[] parameters = ctor.GetParameters();
 
-			var ctor = typeInfo.GetConstructors().Single();
-
-			var arguments = new List<object>();
-
-			foreach (var param in ctor.GetParameters())
+			if (parameters.Length > 0 && resolver == null)
 			{
-			    if (_resolver == null)
-			        throw new InvalidOperationException("Cannot resolve dependencies without a dependency resolver.");
-
-				if (!_resolver.Resolve(param.ParameterType, out var resolvedType))
-					throw new InvalidOperationException("Could not resolve parameter of type: " + param.ParameterType.AssemblyQualifiedName);
-
-				arguments.Add(resolvedType);
+				throw new InvalidOperationException("Cannot resolve dependencies without a dependency resolver.");
 			}
+				
+			var arguments = parameters
+				.Select(p => resolver.Resolve(p.ParameterType, out var resolvedType)
+					? resolvedType
+					: throw new InvalidOperationException(
+						$"Could not resolve parameter of type: {p.ParameterType.AssemblyQualifiedName}"))
+				.ToArray();
 
-			var jobInstance = ctor.Invoke(arguments.ToArray());
+			object jobInstance = ctor.Invoke(arguments);
 
 			switch (jobInstance)
 			{
-			    case Job job:
-			        return job.ExecuteAsync();
-			    case JobInputBase inputJob:
-			        return inputJob.DoExecuteAsync(jobDescription.Input.InputData);
-			    default:
-			        throw new InvalidOperationException("Unknown job type.");
+				case Job job:
+					return job.ExecuteAsync();
+				case JobInputBase inputJob:
+					return inputJob.DoExecuteAsync(jobDescription.Input.InputData);
+				default:
+					throw new ArgumentOutOfRangeException(nameof(jobInstance), "Unknown job type.");
 			}
 		}
 	}

--- a/src/Minion.Core/Interfaces/IJobExecutor.cs
+++ b/src/Minion.Core/Interfaces/IJobExecutor.cs
@@ -5,6 +5,6 @@ namespace Minion.Core.Interfaces
 {
 	public interface IJobExecutor
 	{
-		Task<JobResult> ExecuteAsync(JobDescription job);
+		Task<JobResult> ExecuteAsync(JobDescription job, IDependencyResolver resolver = null);
 	}
 }

--- a/src/Minion.Core/TestingBatchEngine.cs
+++ b/src/Minion.Core/TestingBatchEngine.cs
@@ -7,16 +7,17 @@ namespace Minion.Core
 {
     public class TestingBatchEngine
     {
+        private readonly IJobExecutor _jobExecutor = new DependencyInjectionJobExecutor();
         private readonly ITestingBatchStore _store;
         private readonly IDateSimulationService _dateService;
-        private readonly IJobExecutor _jobExecutor;
+        private readonly IDependencyResolver _resolver;
 
         // TODO: PEBR: Rethink how this is configured
         public TestingBatchEngine(ITestingBatchStore store, IDateSimulationService dateService, IDependencyResolver resolver = null)
         {
             _store = store;
             _dateService = dateService;
-            _jobExecutor = new DependencyInjectionJobExecutor(resolver);
+            _resolver = resolver;
         }
 
         public Task AdvanceToDateAsync(DateTime date, bool throws = true)

--- a/src/Minion.Tests/BathcEngineTests.cs
+++ b/src/Minion.Tests/BathcEngineTests.cs
@@ -59,7 +59,7 @@ namespace Minion.Tests
             };
 
             //Act
-            using (var engine = new BatchEngine(_store, null, _logger, settings))
+            using (var engine = new BatchEngine(_store, _dependencyResolver, _logger, settings))
             {
                 engine.Start();
 
@@ -87,7 +87,7 @@ namespace Minion.Tests
                 .Throws(x => new Exception("Some error"));
 
             //Act
-            using (var engine = new BatchEngine(_store, null, _logger, settings))
+            using (var engine = new BatchEngine(_store, _dependencyResolver, _logger, settings))
             {
                 engine.Start();
 
@@ -120,7 +120,7 @@ namespace Minion.Tests
                 .Throws(x => new Exception("Some error"));
 
             //Act
-            using (var engine = new BatchEngine(_store, null, null, settings))
+            using (var engine = new BatchEngine(_store, _dependencyResolver, null, settings))
             {
                 engine.Start();
 
@@ -246,7 +246,7 @@ namespace Minion.Tests
             await _store.ReleaseJobAsync(job.Id, Arg.Do<JobResult>(x => result = x));
 
             //Act
-            using (var engine = new BatchEngine(_store, null, _logger, settings))
+            using (var engine = new BatchEngine(_store, _dependencyResolver, _logger, settings))
             {
                 engine.Start();
 
@@ -283,7 +283,7 @@ namespace Minion.Tests
             await _store.ReleaseJobAsync(job.Id, Arg.Do<JobResult>(x => result = x));
 
             //Act
-            using (var engine = new BatchEngine(_store, null, _logger, settings))
+            using (var engine = new BatchEngine(_store, _dependencyResolver, _logger, settings))
             {
                 engine.Start();
 
@@ -321,7 +321,7 @@ namespace Minion.Tests
             _store.AcquireJobAsync().Returns(Task.FromResult(job), Task.FromResult((JobDescription)null));
 
             //Act
-            using (var engine = new BatchEngine(_store, null, null, settings))
+            using (var engine = new BatchEngine(_store, _dependencyResolver, null, settings))
             {
                 engine.Start();
 
@@ -357,7 +357,7 @@ namespace Minion.Tests
             _store.AcquireJobAsync().Returns(Task.FromResult(job), Task.FromResult((JobDescription)null), Task.FromResult(job), Task.FromResult((JobDescription)null));
 
             //Act
-            using (var engine = new BatchEngine(_store, null, _logger, settings))
+            using (var engine = new BatchEngine(_store, _dependencyResolver, _logger, settings))
             {
                 engine.Start();
 

--- a/src/Minion.Tests/BathcEngineTests.cs
+++ b/src/Minion.Tests/BathcEngineTests.cs
@@ -38,7 +38,7 @@ namespace Minion.Tests
             InvalidOperationException ex;
 
             //Act
-            using (var engine = new BatchEngine(null, null, settings))
+            using (var engine = new BatchEngine(null, null, null, settings))
             {
                 ex = Assert.Throws<InvalidOperationException>(() => engine.Start());
             }
@@ -59,7 +59,7 @@ namespace Minion.Tests
             };
 
             //Act
-            using (var engine = new BatchEngine(_store, _logger, settings))
+            using (var engine = new BatchEngine(_store, null, _logger, settings))
             {
                 engine.Start();
 
@@ -87,7 +87,7 @@ namespace Minion.Tests
                 .Throws(x => new Exception("Some error"));
 
             //Act
-            using (var engine = new BatchEngine(_store, _logger, settings))
+            using (var engine = new BatchEngine(_store, null, _logger, settings))
             {
                 engine.Start();
 
@@ -120,7 +120,7 @@ namespace Minion.Tests
                 .Throws(x => new Exception("Some error"));
 
             //Act
-            using (var engine = new BatchEngine(_store, null, settings))
+            using (var engine = new BatchEngine(_store, null, null, settings))
             {
                 engine.Start();
 
@@ -143,7 +143,6 @@ namespace Minion.Tests
                 PollingFrequency = 50,
                 HeartBeatFrequency = 5000,
             };
-            MinionConfiguration.Configuration.UseDependencyResolver(_dependencyResolver);
 
             var job1 = Task.FromResult(CreateJob(1));
             var job2 = Task.FromResult(CreateJob(2));
@@ -160,7 +159,7 @@ namespace Minion.Tests
             });
 
             //Act
-            using (var engine = new BatchEngine(_store, _logger, settings))
+            using (var engine = new BatchEngine(_store, _dependencyResolver, _logger, settings))
             {
                 engine.Start();
 
@@ -190,7 +189,6 @@ namespace Minion.Tests
                 PollingFrequency = 50,
                 HeartBeatFrequency = 5000,
             };
-            MinionConfiguration.Configuration.UseDependencyResolver(_dependencyResolver);
 
             var job = Task.FromResult(CreateDelayedJob(300));
 
@@ -206,7 +204,7 @@ namespace Minion.Tests
             });
 
             //Act
-            using (var engine = new BatchEngine(_store, _logger, settings))
+            using (var engine = new BatchEngine(_store, _dependencyResolver, _logger, settings))
             {
                 engine.Start();
 
@@ -248,7 +246,7 @@ namespace Minion.Tests
             await _store.ReleaseJobAsync(job.Id, Arg.Do<JobResult>(x => result = x));
 
             //Act
-            using (var engine = new BatchEngine(_store, _logger, settings))
+            using (var engine = new BatchEngine(_store, null, _logger, settings))
             {
                 engine.Start();
 
@@ -285,7 +283,7 @@ namespace Minion.Tests
             await _store.ReleaseJobAsync(job.Id, Arg.Do<JobResult>(x => result = x));
 
             //Act
-            using (var engine = new BatchEngine(_store, _logger, settings))
+            using (var engine = new BatchEngine(_store, null, _logger, settings))
             {
                 engine.Start();
 
@@ -323,7 +321,7 @@ namespace Minion.Tests
             _store.AcquireJobAsync().Returns(Task.FromResult(job), Task.FromResult((JobDescription)null));
 
             //Act
-            using (var engine = new BatchEngine(_store, null, settings))
+            using (var engine = new BatchEngine(_store, null, null, settings))
             {
                 engine.Start();
 
@@ -359,7 +357,7 @@ namespace Minion.Tests
             _store.AcquireJobAsync().Returns(Task.FromResult(job), Task.FromResult((JobDescription)null), Task.FromResult(job), Task.FromResult((JobDescription)null));
 
             //Act
-            using (var engine = new BatchEngine(_store, _logger, settings))
+            using (var engine = new BatchEngine(_store, null, _logger, settings))
             {
                 engine.Start();
 

--- a/src/Minion.Tests/BathcEngineTests.cs
+++ b/src/Minion.Tests/BathcEngineTests.cs
@@ -38,7 +38,7 @@ namespace Minion.Tests
             InvalidOperationException ex;
 
             //Act
-            using (var engine = new BatchEngine(null, null, null, settings))
+            using (var engine = new BatchEngine(null, null, settings))
             {
                 ex = Assert.Throws<InvalidOperationException>(() => engine.Start());
             }
@@ -59,7 +59,7 @@ namespace Minion.Tests
             };
 
             //Act
-            using (var engine = new BatchEngine(_store, _dependencyResolver, _logger, settings))
+            using (var engine = new BatchEngine(_store, _logger, settings))
             {
                 engine.Start();
 
@@ -87,7 +87,7 @@ namespace Minion.Tests
                 .Throws(x => new Exception("Some error"));
 
             //Act
-            using (var engine = new BatchEngine(_store, _dependencyResolver, _logger, settings))
+            using (var engine = new BatchEngine(_store, _logger, settings))
             {
                 engine.Start();
 
@@ -120,7 +120,7 @@ namespace Minion.Tests
                 .Throws(x => new Exception("Some error"));
 
             //Act
-            using (var engine = new BatchEngine(_store, _dependencyResolver, null, settings))
+            using (var engine = new BatchEngine(_store, null, settings))
             {
                 engine.Start();
 
@@ -143,6 +143,7 @@ namespace Minion.Tests
                 PollingFrequency = 50,
                 HeartBeatFrequency = 5000,
             };
+            MinionConfiguration.Configuration.UseDependencyResolver(_dependencyResolver);
 
             var job1 = Task.FromResult(CreateJob(1));
             var job2 = Task.FromResult(CreateJob(2));
@@ -159,7 +160,7 @@ namespace Minion.Tests
             });
 
             //Act
-            using (var engine = new BatchEngine(_store, _dependencyResolver, _logger, settings))
+            using (var engine = new BatchEngine(_store, _logger, settings))
             {
                 engine.Start();
 
@@ -189,6 +190,7 @@ namespace Minion.Tests
                 PollingFrequency = 50,
                 HeartBeatFrequency = 5000,
             };
+            MinionConfiguration.Configuration.UseDependencyResolver(_dependencyResolver);
 
             var job = Task.FromResult(CreateDelayedJob(300));
 
@@ -204,7 +206,7 @@ namespace Minion.Tests
             });
 
             //Act
-            using (var engine = new BatchEngine(_store, _dependencyResolver, _logger, settings))
+            using (var engine = new BatchEngine(_store, _logger, settings))
             {
                 engine.Start();
 
@@ -246,7 +248,7 @@ namespace Minion.Tests
             await _store.ReleaseJobAsync(job.Id, Arg.Do<JobResult>(x => result = x));
 
             //Act
-            using (var engine = new BatchEngine(_store, _dependencyResolver, _logger, settings))
+            using (var engine = new BatchEngine(_store, _logger, settings))
             {
                 engine.Start();
 
@@ -283,7 +285,7 @@ namespace Minion.Tests
             await _store.ReleaseJobAsync(job.Id, Arg.Do<JobResult>(x => result = x));
 
             //Act
-            using (var engine = new BatchEngine(_store, _dependencyResolver, _logger, settings))
+            using (var engine = new BatchEngine(_store, _logger, settings))
             {
                 engine.Start();
 
@@ -321,7 +323,7 @@ namespace Minion.Tests
             _store.AcquireJobAsync().Returns(Task.FromResult(job), Task.FromResult((JobDescription)null));
 
             //Act
-            using (var engine = new BatchEngine(_store, _dependencyResolver, null, settings))
+            using (var engine = new BatchEngine(_store, null, settings))
             {
                 engine.Start();
 
@@ -357,7 +359,7 @@ namespace Minion.Tests
             _store.AcquireJobAsync().Returns(Task.FromResult(job), Task.FromResult((JobDescription)null), Task.FromResult(job), Task.FromResult((JobDescription)null));
 
             //Act
-            using (var engine = new BatchEngine(_store, _dependencyResolver, _logger, settings))
+            using (var engine = new BatchEngine(_store, _logger, settings))
             {
                 engine.Start();
 

--- a/src/Minion.Tests/DependencyInjectionExecutorTests.cs
+++ b/src/Minion.Tests/DependencyInjectionExecutorTests.cs
@@ -17,7 +17,7 @@ namespace Minion.Tests
 		public DependencyInjectionExecutorTests()
 		{
 			_dependencyResolver = Substitute.For<IDependencyResolver>();
-			_jobExecutor = new DependencyInjectionJobExecutor(_dependencyResolver);
+			_jobExecutor = new DependencyInjectionJobExecutor();
 		}
 
 		[Fact(DisplayName = "Execute Job Without Constructor Dependencies")]
@@ -30,7 +30,7 @@ namespace Minion.Tests
 			};
 
 			//Act
-			var result = await _jobExecutor.ExecuteAsync(job);
+			var result = await _jobExecutor.ExecuteAsync(job, _dependencyResolver);
 
 			//Assert
 			Assert.Equal(ExecutionState.Finished, result.State);
@@ -55,7 +55,7 @@ namespace Minion.Tests
 			});
 
 			//Act
-			var result = await _jobExecutor.ExecuteAsync(job);
+			var result = await _jobExecutor.ExecuteAsync(job, _dependencyResolver);
 
 			//Assert
 			_dependencyResolver.Received(1).Resolve(typeof(ITestService), out _);
@@ -76,7 +76,7 @@ namespace Minion.Tests
 			_dependencyResolver.Resolve(typeof(ITestService), out _).Returns(x => false);
 
 			//Act
-			var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _jobExecutor.ExecuteAsync(job));
+			var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _jobExecutor.ExecuteAsync(job, _dependencyResolver));
 
 			//Assert
 			Assert.Equal("Could not resolve parameter of type: " + typeof(ITestService).AssemblyQualifiedName, ex.Message);
@@ -110,7 +110,7 @@ namespace Minion.Tests
 			});
 
 			//Act
-			var result = await _jobExecutor.ExecuteAsync(job);
+			var result = await _jobExecutor.ExecuteAsync(job, _dependencyResolver);
 
 
 			//Assert
@@ -123,7 +123,7 @@ namespace Minion.Tests
 	    public async Task Execute_Job_With_Dependency_When_Dependency_Resolver_Is_Null()
 	    {
 	        //Arrange
-            var executor = new DependencyInjectionJobExecutor(null);
+            var executor = new DependencyInjectionJobExecutor();
 
             var job = new JobDescription
 	        {


### PR DESCRIPTION
Noticed that the usage of `DependencyInjectionJobExecutor` is a little bit unclear (probably only for me). It allows to pass a `null` during construction, but raises an appropriate exception only in `ExecuteAsync()`. In that case I think it would make sense to either throw an `ArgumentNullException`in the constructor or move `IDependencyResolver` to `ExecuteAsync()` as a parameter. Deciding to go with the former, I also refactored the method and its tests a little bit.