### PR TITLE
Fix/prevent infinite loop

### DIFF
--- a/src/Minion.Core/BatchEngine.cs
+++ b/src/Minion.Core/BatchEngine.cs
@@ -22,6 +22,19 @@ namespace Minion.Core
 
         public BatchEngine()
         {
+            if (MinionConfiguration.Configuration.HeartBeatFrequency <= 0)
+                throw new ArgumentOutOfRangeException(
+                    nameof(MinionConfiguration.Configuration.HeartBeatFrequency),
+                    "Heartbeat frequency must be more than 0");
+            if (MinionConfiguration.Configuration.NumberOfParallelJobs <= 0)
+                throw new ArgumentOutOfRangeException(
+                    nameof(MinionConfiguration.Configuration.NumberOfParallelJobs),
+                    "Number of parallel jobs must be more than 0");
+            if (MinionConfiguration.Configuration.PollingFrequency <= 0)
+                throw new ArgumentOutOfRangeException(
+                    nameof(MinionConfiguration.Configuration.PollingFrequency),
+                    "Polling frequency must be more than 0");
+            
             _store = MinionConfiguration.Configuration.Store;
             _logger = MinionConfiguration.Configuration.Logger;
             _settings = new BatchSettings

--- a/src/Minion.Core/MinionConfiguration.cs
+++ b/src/Minion.Core/MinionConfiguration.cs
@@ -9,7 +9,12 @@ namespace Minion.Core
     {
         private readonly DatePassThruService _dateService = new DatePassThruService(new UtcDateService());
 
-        public static MinionConfiguration Configuration { get; } = new MinionConfiguration();
+        public static MinionConfiguration Configuration { get; } = new MinionConfiguration
+        {
+            HeartBeatFrequency = 2000,
+            NumberOfParallelJobs = 2,
+            PollingFrequency = 500
+        };
 
         public IBatchStore Store { get; private set; }
         public IDateService DateService => _dateService;


### PR DESCRIPTION
If we follow the readme file we'll miss the important setup of `HeartBeatFrequency`, `NumberOfParallelJobs`, and `PollingFrequency`. So default values for these properties would be 0.

But if `HeartBeatFrequency` is 0 then the `HeartBeatAsync()` method goes into the infinite loop. To prevent that I've added guard clauses and also set some non-zero values for those properties as defaults. (But probably we should remove the hardcoded values to some setup file or something.)